### PR TITLE
Improve makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,15 +2,18 @@ exec = test
 sources = $(wildcard src/*.c)
 sources += examples/ex.c
 objects = $(sources:.c=.o)
-flags = -g -Wall -std=c99
+LDFLAGS = -lpthread
+INCLUDE = -I./src
+CFLAGS = -g -Wall -std=gnu99 $(INCLUDE)
+CC = gcc
 
 $(exec): $(objects)
-	gcc $(objects) $(flags) -o $(exec)
+	$(CC) $^ $(LDFLAGS) -o $@
 
-%.o: %.c src/%.h
-	gcc -c $(flags) $< -o $@
+%.o: %.c $(sources)
+	$(CC) -c $(CFLAGS) $< -o $@
 
 clean:
-	-rm $(exec)
-	-rm src/*.o
-	-rm examples/*.o
+	rm -f $(exec) src/*.o examples/*.o
+
+.PHONY: clean


### PR DESCRIPTION
The provided Makefile doesn't work on Linux. I get the following error:

```
[a1760e1][~/programming/ihct]$ make
cc    -c -o src/ihct.o src/ihct.c
cc    -c -o src/vector.o src/vector.c
cc    -c -o examples/ex.o examples/ex.c
examples/ex.c:1:10: fatal error: ihct.h: No such file or directory
 #include "ihct.h"
          ^~~~~~~~
compilation terminated.
<builtin>: recipe for target 'examples/ex.o' failed
```

I went in and fixed a few bugs/style issues:

1. Pattern substitution rules with multiple dependencies depend on every element. So if you have the rule `%.o: %.c src/%.h`, and you have a file `example/ex.o`, then that will also expect the file `src/example/ex.h` to exist. Since that file doesn't exist, Make will apply an implict rule instead.
2. clean target not marked as 'phony.' If you don't mark the clean target as phony, then the clean target will not run if there is a file named 'clean' in the current directory.
3. Add libraries to include path.
4. Link using pthreads. If I don't include this, I get the following error:

	  ```
	  src/ihct.o: In function `ihct_run_specific':
	  /home/nick/programming/ihct/src/ihct.c:222: undefined reference to `pthread_create'
	  /home/nick/programming/ihct/src/ihct.c:236: undefined reference to `pthread_cancel'
	  /home/nick/programming/ihct/src/ihct.c:243: undefined reference to `pthread_join'
	  collect2: error: ld returned 1 exit status
	  Makefile:11: recipe for target 'test' failed
	  ```

5. Use gnu99 instead of c99. This enables feature test macros for sigaction. If I don't do this, I get this error:

	  ```
	  gcc -c -g -Wall -std=c99 -I./src src/ihct.c -o src/ihct.o
	  src/ihct.c: In function ‘ihct_set_sigaction’:
	  src/ihct.c:28:5: warning: implicit declaration of function ‘sigaction’ [-Wimplicit-function-declaration]
	       sigaction(SIGSEGV, &recover_action, NULL);
	       ^~~~~~~~~
	  src/ihct.c: In function ‘ihct_setup_recover_action’:
	  src/ihct.c:45:19: error: invalid use of undefined type ‘struct sigaction’
	       recover_action.sa_handler = &ihct_recovery_proc;
	  ```